### PR TITLE
Add a "static" configuration that uses static linking on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         dc:
           - ldc-latest
           - dmd-latest

--- a/dub.json
+++ b/dub.json
@@ -13,4 +13,19 @@
         "volumeinfo" : "~>0.2.2",
         "inilike" : "~>1.2.0"
     },
+
+    "configurations": [
+        {
+            "name": "static",
+            "versions": [
+                "TrashCanStatic"
+            ],
+            "lflags-osx": [
+                "-framework", "CoreServices"
+            ]
+        },
+        {
+            "name": "dynamic",
+        }
+    ]
 }


### PR DESCRIPTION
The `dlopen()` call fails on the latest macOS versions:

> dlopen(CoreServices.framework/Versions/A/CoreServices, 0x0002): tried: 'CoreServices.framework/Versions/A/CoreServices' (no such file), '/System/Volumes/Preboot/Cryptexes/OSCoreServices.framework/Versions/A/CoreServices' (no such file), '/usr/lib/CoreServices.framework/Versions/A/CoreServices' (no such file, not in dyldcache), 'CoreServices.framework/Versions/A/CoreServices' (no such file)

Using the "-framework CoreServices" linker flag statically links against the CoreServices framework instead, which should be the best approach for most applications.